### PR TITLE
Fix search query not acceping queries with spaces

### DIFF
--- a/rutor.py
+++ b/rutor.py
@@ -90,7 +90,7 @@ class rutor(object):
 
     def search_page(self, what, cat, start):
         params = {'url': self.url,
-                'q': urllib.parse.quote(what),
+                'q': what,
                 'f': self.supported_categories[cat],
                 'start': start}
         dat = self.retrieve_url(self.query_pattern % params).decode('utf-8')


### PR DESCRIPTION
Urlencode is not needed here, because qbittorrent already supplies encoded query string, e.g. "Ubuntu+Linux".

This also fixes issues with non-ascii characters in https://github.com/Pireo/hello-world/issues/3